### PR TITLE
Add xts kernel module for RHEL/SLES

### DIFF
--- a/scripts/module-setup.sh
+++ b/scripts/module-setup.sh
@@ -36,4 +36,5 @@ installkernel()
 {
     instmods tpm_crb
     instmods hyperv-keyboard
+    instmods xts
 }


### PR DESCRIPTION
Needed for compatible processor mode in Hyper-V. Ubuntu has it added.