### PR TITLE
Fixed missing xts module in initrd

### DIFF
--- a/scripts/module-setup.sh
+++ b/scripts/module-setup.sh
@@ -29,7 +29,5 @@ install()
 
 installkernel()
 {
-    instmods tpm_crb
-    instmods hyperv-keyboard
-    instmods xts
+    hostonly='' instmods tpm_crb hyperv-keyboard xts
 }


### PR DESCRIPTION
Need hostonly='' flag to actually force dracut to add the module.