### PR TITLE
Passphrase error

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -26,6 +26,7 @@ sources:
 	@$(MAKE) -s -C .. bindist > /dev/null 
 	@mkdir $(DEBDIR)
 	@tar xf $(TARBALL) -C $(DEBDIR)
+	@rm -rf $(DEBDIR)/$(NAME)-$(VERSION)-x86_64/install
 
 get-build-deps:
 	@apt-get -qq -y install build-essential dh-make devscripts 

--- a/lsvmprep
+++ b/lsvmprep
@@ -207,8 +207,23 @@ check_root_passphrase()
         exit 1
     fi
 
-    echo -n "passphrase" | cryptsetup luksDump --dump-master-key --key-file=- $rootdev 2> /dev/null > /dev/null
+    # Check whether cryptsetup program exists.
+    if [ ! -x "/sbin/cryptsetup" ]; then
+        echo "$0: ERROR: /sbin/cryptsetup not found"
+        echo ""
+        exit 1
+    fi
 
+    # Check whether root partition is encrypted.
+    /sbin/cryptsetup luksDump $rootdev 2> /dev/null > /dev/null
+    if [ "$?" != "0" ]; then
+        echo "$0: ERROR: The root partition is not a LUKS partition: $rootdev"
+        echo ""
+        exit 1
+    fi
+
+    # Check whether root partition is encrypted with "passprhase"
+    echo -n "passphrase" | /sbin/cryptsetup luksDump --dump-master-key --key-file=- $rootdev 2> /dev/null > /dev/null
     if [ "$?" != "0" ]; then
         echo "$0: ERROR: The root partition passphrase must be 'passphrase'"
         echo ""

--- a/rpm/SPECS/lsvmtools.spec
+++ b/rpm/SPECS/lsvmtools.spec
@@ -31,6 +31,8 @@ make install DESTDIR=$RPM_BUILD_ROOT RELEASE=1
 %files
 %defattr(-,root,root)
 
+%exclude /opt/lsvmtools-1.0.0/scripts/install
+
 %doc %attr(0644,root,root) /opt/lsvmtools-1.0.0/VERSION
 %doc %attr(0644,root,root) /opt/lsvmtools-1.0.0/LICENSE
 


### PR DESCRIPTION
(1) Fixed misleading error about root drive having to have "passphrase" as passphrase.
(2) Removed install script from .deb package.