### PR TITLE
Askpass

### DIFF
--- a/lsvmprep
+++ b/lsvmprep
@@ -214,6 +214,13 @@ check_root_passphrase()
         exit 1
     fi
 
+    # Check whether /lib/cryptsetup/askpass program exists.
+    if [ ! -x "/lib/cryptsetup/askpass" ]; then
+        echo "$0: ERROR: /lib/cryptsetup/askpass not found"
+        echo ""
+        exit 1
+    fi
+
     # Check whether root partition is encrypted.
     /sbin/cryptsetup luksDump $rootdev 2> /dev/null > /dev/null
     if [ "$?" != "0" ]; then

--- a/lsvmprep
+++ b/lsvmprep
@@ -215,10 +215,12 @@ check_root_passphrase()
     fi
 
     # Check whether /lib/cryptsetup/askpass program exists.
-    if [ ! -x "/lib/cryptsetup/askpass" ]; then
-        echo "$0: ERROR: /lib/cryptsetup/askpass not found"
-        echo ""
-        exit 1
+    if [ "${vendor}" == "ubuntu" ]; then
+        if [ ! -x "/lib/cryptsetup/askpass" ]; then
+            echo "$0: ERROR: /lib/cryptsetup/askpass dependency not found"
+            echo ""
+            exit 1
+        fi
     fi
 
     # Check whether root partition is encrypted.


### PR DESCRIPTION
Add check to lsvmprep to work around bug in Ubuntu where executing "apt-get remove cryptsetup" fails to remove the cryptsetup program (it partially removes select cryptsetup components including askpass). 